### PR TITLE
Changed No output to blank

### DIFF
--- a/src/bika/extras/browser/listingview/analysisservices.py
+++ b/src/bika/extras/browser/listingview/analysisservices.py
@@ -125,7 +125,7 @@ class AnalysisServicesListingViewAdapter(object):
 
         # Hidden
         hidden = obj.Hidden
-        hidden_value = _("Yes") if hidden else _("No")
+        hidden_value = _("Yes") if hidden else _("")
         item["Hidden"] = hidden_value
 
         return item

--- a/src/bika/extras/browser/listingview/bika_analysisprofiles.py
+++ b/src/bika/extras/browser/listingview/bika_analysisprofiles.py
@@ -82,7 +82,7 @@ class AnalysisProfilesListingViewAdapter(object):
 
         # Use Analysis Profile Price
         use_price = obj.getUseAnalysisProfilePrice()
-        use_price_value = _("Yes") if use_price else _("No")
+        use_price_value = _("Yes") if use_price else _("")
         item["UsePrice"] = use_price_value
 
         return item

--- a/src/bika/extras/browser/listingview/sampletemplates.py
+++ b/src/bika/extras/browser/listingview/sampletemplates.py
@@ -84,12 +84,12 @@ class SampleTemplatesListingViewAdapter(object):
 
         # Composite
         composite = obj.getComposite()
-        composite_value = _("Yes") if composite else _("No")
+        composite_value = _("Yes") if composite else _("")
         item["Composite"] = composite_value
 
         # Lab Sample
         lab_sample = obj.getSamplingRequired()
-        lab_sample_value = _("Yes") if lab_sample else _("No")
+        lab_sample_value = _("Yes") if lab_sample else _("")
         item["LabSample"] = lab_sample_value
 
         # Partitions


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-821, https://bika.atlassian.net/browse/LIMS-229

## Current behavior before PR
Remove "No" value from Yes/No columns. Remove them from(Section : Column):
Analysis Services : Hidden
Analysis Profiles : Use Price
Sample Templates : Composite, Lab Sample
## Desired behavior after PR is merged
"No" values were removed from the above mentioned columns.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
