### PR TITLE
Added Instruments Column to Analysis Services

### DIFF
--- a/src/bika/extras/browser/listingview/analysisservices.py
+++ b/src/bika/extras/browser/listingview/analysisservices.py
@@ -147,10 +147,8 @@ class AnalysisServicesListingViewAdapter(object):
         if instruments:
             titles = map(api.get_title, instruments)
             links = map(get_link_for, instruments)
-            item["Insatruments"] = ",".join(titles)
+            item["Instruments"] = ",".join(titles)
             item["replace"]["Instruments"] = ", ".join(links)
-        else:
-            item["Instruments"] = ""
 
         return item
 

--- a/src/bika/extras/browser/listingview/analysisservices.py
+++ b/src/bika/extras/browser/listingview/analysisservices.py
@@ -9,6 +9,7 @@ from bika.extras import is_installed
 from bika.extras.config import _
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
+from bika.lims.utils import get_link_for
 
 
 class AnalysisServicesListingViewAdapter(object):
@@ -60,6 +61,15 @@ class AnalysisServicesListingViewAdapter(object):
         hidden = [
             ("Hidden", {"toggle": False, "sortable": False, "title": _("Hidden")})
         ]
+        instruments = [
+            (
+                "Instruments", {
+                    "toggle": False,
+                    "sortable": False,
+                    "title": _("Instruments")
+                }
+            )
+        ]
 
         self.listing.columns.update(description)
         self.listing.columns.update(commercial_id)
@@ -69,6 +79,7 @@ class AnalysisServicesListingViewAdapter(object):
         self.listing.columns.update(vat)
         self.listing.columns.update(bulk_price)
         self.listing.columns.update(hidden)
+        self.listing.columns.update(instruments)
 
         for i in range(len(self.listing.review_states)):
             self.listing.review_states[i]["columns"].append("Description")
@@ -79,6 +90,7 @@ class AnalysisServicesListingViewAdapter(object):
             self.listing.review_states[i]["columns"].append("Vat")
             self.listing.review_states[i]["columns"].append("BulkPrice")
             self.listing.review_states[i]["columns"].append("Hidden")
+            self.listing.review_states[i]["columns"].append("Instruments")
 
     def folder_item(self, obj, item, index):
         if not is_installed():
@@ -129,6 +141,16 @@ class AnalysisServicesListingViewAdapter(object):
         hidden = obj.Hidden
         hidden_value = _("Yes") if hidden else _("")
         item["Hidden"] = hidden_value
+
+        # Instruments
+        instruments = obj.getInstruments()
+        if instruments:
+            titles = map(api.get_title, instruments)
+            links = map(get_link_for, instruments)
+            item["Insatruments"] = ",".join(titles)
+            item["replace"]["Instruments"] = ", ".join(links)
+        else:
+            item["Instruments"] = ""
 
         return item
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1425

## Current behavior before PR
No column for Instruments found for Analysis Services.

## Desired behavior after PR is merged
Added a column for Instruments found for Analysis Services.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
